### PR TITLE
Do not show "Data" labels on top of sticky filters

### DIFF
--- a/mockup1/assets/76f6034.css
+++ b/mockup1/assets/76f6034.css
@@ -342,6 +342,7 @@ ul#container > li > p {
 
 ul.taglist li{
   display: inline-block;
+  position: static;
   color: black;
   font-size: 12px;
   line-height: 10px;
@@ -460,7 +461,7 @@ ul#container > li::before {
 li.accessibility {background-color: #ede5f4}
 li.browser {background-color: #a8c5a9}
 li.css {background-color: #a7cd78}
-li.data { position: static; background-color: #94c4b4; }
+li.data {background-color: #94c4b4}
 li.dom {background-color: #e48497}
 li.graphics {background-color: #82e3ff}
 li.html {background-color: #ff9c49}

--- a/mockup1/assets/76f6034.css
+++ b/mockup1/assets/76f6034.css
@@ -460,7 +460,7 @@ ul#container > li::before {
 li.accessibility {background-color: #ede5f4}
 li.browser {background-color: #a8c5a9}
 li.css {background-color: #a7cd78}
-li.data {background-color: #94c4b4}
+li.data { position: static; background-color: #94c4b4; }
 li.dom {background-color: #e48497}
 li.graphics {background-color: #82e3ff}
 li.html {background-color: #ff9c49}


### PR DESCRIPTION
This overwrites a CSS rule in `minimum.css`.
Note that this PR isn't for `master`, but for `question-mark` (#48).

Fixes #43.