### PR TITLE
Fix bug: reset ain't resetting

### DIFF
--- a/mockup1/assets/filtering.js
+++ b/mockup1/assets/filtering.js
@@ -71,6 +71,10 @@
 
   let filters, summary, ticker, list, filtersOffset;
 
+  const RESET = () => {
+    setTimeout(APPLY, 50);
+  };
+
   const APPLY = (e) => {
     summary.innerHTML = 'Filtering&hellip;';
     summary.classList.add('busy');
@@ -143,7 +147,7 @@
     filters.tag.addEventListener('change', APPLY);
     filters.status.addEventListener('change', APPLY);
     filters.version.addEventListener('change', APPLY);
-    filters.addEventListener('reset', APPLY);
+    filters.addEventListener('reset', RESET);
     filters.addEventListener('submit', IGNORE_EVENT);
     window.addEventListener('popstate', APPLY);
     window.addEventListener('resize', TOGGLE_STICKY);


### PR DESCRIPTION
cf https://github.com/w3c/tr-pages/pull/74#issuecomment-399439946

Well spotted, @deniak.

The solution is ugly, but I haven't found an elegant one. (The event `reset` triggers necessarily *before* the form is actually reset; alternatives are to hide a true input `reset` and use a visible input `button` to trigger it, or to fake reset by explicitly resetting all inputs by hand&hellip;)