### PR TITLE
Added a tag for the publishing@W3C activity

### DIFF
--- a/tags.md
+++ b/tags.md
@@ -4,6 +4,7 @@
 * Browser: Specifications for Web browsers and other interactive user agents
 * CSS: How documents are presented on screens using CSS
 * Data: Specifications to facilitate the creation, exchange, and usage of semantically rich data on the Web
+* Digital Publishing: Specifications dealing with digital publishing like electronic books or journals, and based on W3C technologies such as HTML, SVG, CSS, or MathML.
 * DOM: Specifications describing the Document Object Model (DOM)
 * Graphics: Specifications dealing with graphical content (image formats, web fonts, canvas, etc)
 * HTML: Defines the HyperText Markup Language (HTML) format and its extensions


### PR DESCRIPTION
I did not want to use the term "publishing", because this could be misunderstood with the issues around publishing specifications on /TR. I realize that "Digital Publishing" is a bit long, but I did not find anything better...