### PR TITLE
Add hyperlinks to W3C Process's definition of 'W3C Group'

### DIFF
--- a/documents.html
+++ b/documents.html
@@ -289,7 +289,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
     <span id="editor-draft-finding"></span>
 
-    <p>An Editor's draft is a document produced by a <abbr title="World Wide Web Consortium">W3C</abbr> Group.</p>
+    <p>An Editor's draft is a document produced by a <a href="https://www.w3.org/Consortium/Process/#w3c-group"><abbr title="World Wide Web Consortium">W3C</abbr> Group</a>.</p>
 
     <p>An editor's draft is a document allowing the Group to iterate internally on its content for consideration.
       Editor's Drafts are works in progress inside a <abbr title="World Wide Web Consortium">W3C</abbr> Group and are not required to have the consensus of the Group participants.
@@ -312,7 +312,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 
     <p>
       The document listed in this section have no <abbr title="World Wide Web Consortium">W3C</abbr> standing, endorsement, or patent commitments. Those documents are not
-      part of <abbr title="World Wide Web Consortium">W3C</abbr> Group.
+      part of <a href="https://www.w3.org/Consortium/Process/#w3c-group"><abbr title="World Wide Web Consortium">W3C</abbr> Group</a>.
     </p>
 
     <dl>
@@ -467,7 +467,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <section id="standardtrack"><div class="header-wrapper"><h2 id="x4-w3c-standardization-track"><bdi class="secno">4. </bdi><abbr title="World Wide Web Consortium">W3C</abbr> Standardization track</h2><a class="self-link" href="#standardtrack" aria-label="Permalink for Section 4."></a></div>
 
 
-<p>The classes of specifications listed in this section have received different levels of review by <abbr title="World Wide Web Consortium">W3C</abbr> Members, by software developers, and by other <abbr title="World Wide Web Consortium">W3C</abbr> groups and interested parties according to <abbr title="World Wide Web Consortium">W3C</abbr> Process. These specifications are intended to eventually receive endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>.
+<p>The classes of specifications listed in this section have received different levels of review by <abbr title="World Wide Web Consortium">W3C</abbr> Members, by software developers, and by <a href="https://www.w3.org/Consortium/Process/#w3c-group"><abbr title="World Wide Web Consortium">W3C</abbr> Groups</a> and interested parties according to <abbr title="World Wide Web Consortium">W3C</abbr> Process. These specifications are intended to eventually receive endorsement by <abbr title="World Wide Web Consortium">W3C</abbr>.
 
 </p><p><a href="https://www.w3.org/Consortium/Process/#recs-and-notes">Technical
   reports on the <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation Track</a> are developed in order to ultimately
@@ -559,7 +559,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <section id="standard"><div class="header-wrapper"><h2 id="x5-standard"><bdi class="secno">5. </bdi>Standard</h2><a class="self-link" href="#standard" aria-label="Permalink for Section 5."></a></div>
 
 
-<p>The classes of specifications listed in this section have been formally reviewed by <abbr title="World Wide Web Consortium">W3C</abbr> Members, by software developers, and by <abbr title="World Wide Web Consortium">W3C</abbr> groups and interested parties. These specifications are endorsed by the <abbr title="World Wide Web Consortium">W3C</abbr> Director and <abbr title="World Wide Web Consortium">W3C</abbr> Membership (except if Rescinded).
+<p>The classes of specifications listed in this section have been formally reviewed by <abbr title="World Wide Web Consortium">W3C</abbr> Members, by software developers, and by <a href="https://www.w3.org/Consortium/Process/#w3c-group"><abbr title="World Wide Web Consortium">W3C</abbr> Groups</a> and interested parties. These specifications are endorsed by the <abbr title="World Wide Web Consortium">W3C</abbr> Director and <abbr title="World Wide Web Consortium">W3C</abbr> Membership (except if Rescinded).
 
 
   </p><section id="REC"><div class="header-wrapper"><h3 id="x5-1-recommendation"><bdi class="secno">5.1 </bdi>Recommendation</h3><a class="self-link" href="#REC" aria-label="Permalink for Section 5.1"></a></div>


### PR DESCRIPTION
Re https://github.com/w3c/tr-pages/issues/102

Works towards clarifying the intended reference to "W3C Group" by linking to the definition in W3C Process: https://www.w3.org/Consortium/Process/#w3c-group

